### PR TITLE
Support for BDF files

### DIFF
--- a/FONT_TO_PY.md
+++ b/FONT_TO_PY.md
@@ -45,8 +45,8 @@ installed using `pip3`. On Linux (you may need a root prompt):
 # Usage
 
 `font_to_py.py` is a command line utility written in Python 3. It is run on a
-PC. It takes as input a font file with a `ttf` or `otf` extension and a
-required height in pixels and outputs a Python 3 source file. The pixel layout
+PC. It takes as input a font file with a `ttf`, `otf`, or `bdf` extension and a
+required height in pixels (for bitmap `bdf` fonts, height can be automatically determined) and outputs a Python 3 source file. The pixel layout
 is determined by command arguments. By default fonts are stored in variable
 pitch form. This may be overidden by a command line argument.
 
@@ -69,8 +69,8 @@ $ font_to_py.py -k extended FreeSans.ttf 23 my_extended_font.py
 
 ### Mandatory positional arguments:
 
- 1. Font file path. Must be a ttf or otf file.
- 2. Height in pixels.
+ 1. Font file path. Must be a ttf, otf, or bdf file.
+ 2. Height in pixels. Specify `0` for bdf bitmap files to automatically use native height
  3. Output file path. Filename must have a .py extension (unless writing a
  binary font).
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ This comprises three components, links to docs below:
 # font_to_py.py
 
 This command line utility is written in Python 3 and runs on a PC. It takes
-as input a font file in `ttf` or `otf` form together with a height in pixels
+as input a font file in `ttf`, `otf`, or `bdf` form together with a height in pixels 
+(for bitmap fonts in `bdf` format, the height can be automatically detected)
 and outputs a Python source file containing the font as a bitmap. Fixed and
 variable pitch rendering are supported. The design has the following aims:
 

--- a/font_to_py.py
+++ b/font_to_py.py
@@ -622,7 +622,7 @@ if __name__ == "__main__":
         quit("Font filename does not exist")
 
     if not os.path.splitext(args.infile)[1].upper() in ('.TTF', '.OTF', '.BDF'):
-        quit("Font file should be a ttf or otf file.")
+        quit("Font file should be a ttf, otf, or bdf file.")
 
     if args.binary:
         if os.path.splitext(args.outfile)[1].upper() == '.PY':

--- a/font_to_py.py
+++ b/font_to_py.py
@@ -618,7 +618,7 @@ if __name__ == "__main__":
     if not os.path.isfile(args.infile):
         quit("Font filename does not exist")
 
-    if not os.path.splitext(args.infile)[1].upper() in ('.TTF', '.OTF'):
+    if not os.path.splitext(args.infile)[1].upper() in ('.TTF', '.OTF', '.BDF'):
         quit("Font file should be a ttf or otf file.")
 
     if args.binary:


### PR DESCRIPTION
Add support to convert bitmap BDF fonts to micropython fonts. 
Makes it possible to use BDF bitmap fonts developped for other embedded architectures, eg https://github.com/olikraus/u8g2/wiki/fntlistall