### PR TITLE
Avoid premature linebreaks from the spacing between characters

### DIFF
--- a/writer/writer.py
+++ b/writer/writer.py
@@ -91,7 +91,7 @@ class Writer():
         self.row_clip = False  # Clip or scroll when screen full
         self.col_clip = False  # Clip or new line when row is full
         self.wrap = True  # Word wrap
-        self.char_space = 0 # Assumed spacing between characters to avoid premature wrapping/clipping
+        self.char_space = 0 # Define the whitespace between characters, to avoid premature wrapping/clipping
         self.cpos = 0
         self.tab = 4
 


### PR DESCRIPTION
Implementing a solution to avoid lines from wrapping or clipping prematurely, if the only pixels falling off the edge of the display would be  the blank intra-character spacing to the right of the last character.

Particularly relevant for displays with a very small number of pixels (LED matrixes, flipdots, etc), where goal is to fit as many characters as possible into the space available.

Approach allows the user to specify how many pixels of whitespace exist to the right of characters using `set_clip()`. Those whitespace pixels are ignored when checking if the string fits in the width of the screen:
--> The new `self.char_space` attribute is subtracted from the line length when determining whether to wrap, clip, etc.

`self.char_space = 0` by default, to maintain compatability with existing approach.